### PR TITLE
Fix likely typo with WGS84 epoch

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Table 2. Regional Geodetic Coordinate System
 |24|	MGRF2020(2020.0)=ITRF2020(2020.0)|	2020.0|	MYS|
 |25|	MTRF2000(2004.0)=ITRF2000(2004.0)|	2004.0|	ARE|
 |26|	SIRGAS2000(2000.4)=ITRF2000(2000.4)	|2000.4|	South America|
-|27|	WGS84(G2139)(20xx.5)<sup>1</sup>|	20xx.51|	Other regions|
+|27|	WGS84(G2139)(20xx.5)<sup>1</sup>|	20xx.5|	Other regions|
 
 <sup>1</sup> The WGS84 is used in AUTO_WGS84, since WGS84 is a global dynamic coordinate system, where the coordinate of the station will change due to the global plate tectonics movement. The WGS84(G2139)(20xx.50) with the middle of current year is adapted to best match the current GPS real-time orbit based on NGS recommendations.  
 <sup>2</sup> GEODNET does not provide RTK service in this region now, can broadcast partnerships’ RTK/VRS service in this region based on user requests.


### PR DESCRIPTION
I'm pretty sure this is a typo, and the `1` was copied accidentally from the footnote number. If the `0.01` is intentional, please feel free to close this out!